### PR TITLE
Implement pagination with an iterator-like API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,12 @@
   "parserOptions": {
     "ecmaVersion": 2017
   },
+  "fix": true,
   "extends": "eslint:recommended",
   "rules": {
+    "no-else-return": 0,
     "no-console": 0,
     "eqeqeq": 1,
-    "no-else-return": 1,
     "array-bracket-spacing": 1,
     "brace-style": [1, "1tbs", {
       "allowSingleLine": true
@@ -44,6 +45,7 @@
     "onGET": false,
     "onPOST": false,
     "jsonOk": false,
+    "ok": false,
     "wait": false,
     "respondWith": false,
     "serverError": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "extends": "eslint:recommended",
   "rules": {
     "no-console": 0,
@@ -26,6 +29,7 @@
     "html"
   ],
   "globals": {
+    "Promise": false,
     "Polymer": false,
     "sinon": false,
     "assert": false,
@@ -33,6 +37,17 @@
     "fixture": false,
     "describe": false,
     "WCT": false,
-    "beforeEach": false
+    "beforeEach": false,
+    "afterEach": false,
+    "expect": false,
+    "onRequest": false,
+    "onGET": false,
+    "onPOST": false,
+    "jsonOk": false,
+    "wait": false,
+    "respondWith": false,
+    "serverError": false,
+    "getRequestParam": false,
+    "ArrayBuffer": false
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "github-ajax",
   "version": "0.2.0",
   "main": "github-ajax.html",
-  "description": "iron-ajax wrapper specialised to the GitHub API",
+  "description": "Fetch API wrapper targeted towards usage with the GitHub API",
   "authors": [
     "Preview-Code team"
   ],
@@ -13,8 +13,7 @@
   "license": "BSD-3-Clause",
   "private": true,
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.8.0",
-    "iron-ajax": "^1.4.3"
+    "polymer": "Polymer/polymer#^1.8.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "github-ajax",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "github-ajax.html",
   "description": "Fetch API wrapper targeted towards usage with the GitHub API",
   "authors": [

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -34,7 +34,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
         canFetchMore: {
           type: Boolean,
           readOnly: true,
-          notify: true
+          notify: true,
+          value: true
         },
 
         /**
@@ -58,16 +59,6 @@ This code may only be used under the BSD style license found in LICENSE.txt
         perPage: {
           type: Number,
           observer: '_onPerPageChange'
-        },
-
-        /**
-         * The nth page from GitHub, used to traverse through pagination.
-         * @type {Number}
-         */
-        page: {
-          type: Number,
-          readOnly: true,
-          observer: '_onPageChange'
         },
 
         /**
@@ -95,19 +86,13 @@ This code may only be used under the BSD style license found in LICENSE.txt
         },
 
         /**
-         * Set this property to true to completely disable caching of GitHub responses.
-         * Mainly used for testing.
-         */
-        noCache: {
-          type: Boolean,
-          value: false
-        },
-
-        /**
          * The url to query, e.g.: https://api.github.com/users
          * @type {String}
          */
-        url: String,
+        url: {
+          type: String,
+          observer: '_resetPagination'
+        },
 
         /**
          * URL query parameters to send with the request.
@@ -126,7 +111,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
          */
         method: {
           type: String,
-          value: 'GET'
+          value: 'GET',
+          observer: '_resetPagination'
         },
 
         /**
@@ -152,7 +138,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
          */
         contentType: {
           type: String,
-          value: null
+          value: null,
+          observer: '_resetPagination'
         },
 
          /**
@@ -178,7 +165,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
          */
         body: {
           type: Object,
-          value: null
+          value: null,
+          observer: '_resetPagination'
         },
 
         /**
@@ -197,7 +185,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
          */
         handleAs: {
           type: String,
-          value: 'json'
+          value: 'json',
+          observer: '_resetPagination'
         },
 
         /**
@@ -244,13 +233,15 @@ This code may only be used under the BSD style license found in LICENSE.txt
           notify: true,
           readOnly: true
         },
-        
-        _cacheName: {
-          type: String,
-          value: 'github-cache-v1'
+
+        _nextPageLink: {
+          type: String
         }
       },
       
+      observers: [
+        '_resetPagination(params.*, headers.*)'
+      ],
 
       attached: function() {
         if (sharedToken) this.accessToken = sharedToken;
@@ -263,10 +254,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
       _onPerPageChange: function(itemCount) {
         if (this.params) this.params['per_page'] = itemCount;
-      },
-
-      _onPageChange: function(newPage) {
-        if (this.params) this.params['page'] = newPage
+        this._resetPagination();
       },
 
       _onTokenChange: function(newToken) {
@@ -356,8 +344,8 @@ This code may only be used under the BSD style license found in LICENSE.txt
             headers.set(header, this.headers[header].toString());
           }
 
-          if (acceptType && !headers.has('accept')) {
-            headers.set('accept', acceptType);
+          if (acceptType && !headers.has('Accept')) {
+            headers.set('Accept', acceptType);
           }
         }
         return headers;
@@ -419,12 +407,42 @@ This code may only be used under the BSD style license found in LICENSE.txt
        * @return {Promise}
        */
       generateRequest: function() {
+        this._setAllResults([]);
+        return this._generateRequest(this.requestUrl);
+      },
+
+      /**
+       * If `canFetchMore` returns true, this method will
+       * request the next page of results.
+       * These results will be concatenated to `allResults`.
+       * 
+       * Returns a Promise that resolves when the request completes and after any events have been fired.
+       * Just like `generateRequest`, this method will fire `github-response` & co events.
+       * @return {Promise}
+       */
+      fetchMore: function() {
+        if (this.canFetchMore) {
+          if (this._nextPageLink) {
+            return this._generateRequest(this._nextPageLink);
+          } else {
+            return this.generateRequest();
+          }
+        }
+      },
+
+      _appendResults: function(responseBody) {
+        if (!responseBody) return;
+        this._setAllResults(this.allResults.concat(responseBody));
+        this._onResponse(responseBody);
+      },
+
+      _generateRequest: function(url) {
         if (sharedToken && this.accessToken !== sharedToken) {
           this.accessToken = sharedToken;
         }
 
-        const headers = this.requestHeaders;
-        const request = new Request(this.requestUrl, {
+        const headers = this.requestHeaders
+        const request = new Request(url, {
             method: this.method,
             headers: headers,
             body: this._encodeBody(headers)
@@ -433,6 +451,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         return this._fetchOrTimeout(request)
           .then(this._checkResponseForErrors.bind(this))
           .then(this._decodeResponseBody.bind(this))
+          .then(this._appendResults.bind(this))
           .then(this._onResponse.bind(this))
           .catch(this._onError.bind(this));
       },
@@ -473,14 +492,48 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
       _decodeResponseBody: function(response) {
         if (!response) return;
+
+        var body;
         if (this.handleAs === 'json') {
-          return response.json();
+          body = response.json();
         } else if (this.handleAs === 'text') {
-          return response.text();
+          body = response.text();
         } else if (this.handleAs === 'arrayBuffer') {
-          return response.arrayBuffer();
+          body = response.arrayBuffer();
+        } else {
+          throw new Error('Unrecognized `handleAs` property: ' + this.handleAs);
         }
-        throw new Error('Unrecognized `handleAs` property: ' + this.handleAs);
+
+        this._updatePagination(response.headers.get('Link'));
+
+        return body;
+      },
+
+      _resetPagination: function() {
+        this._setCanFetchMore(true);
+        this._nextPageLink = undefined;
+      },
+
+      _updatePagination: function(linkHeader) {
+        const pageLinks = this._parseLinkHeader(linkHeader);
+        if (pageLinks.next) {
+          this._setCanFetchMore(true);
+          this._nextPageLink = pageLinks.next;
+        } else {
+          this._setCanFetchMore(false);
+          this._nextPageLink = undefined;
+        }
+      },
+
+      _parseLinkHeader: function(linkHeader) {
+        const pageLinks = {}
+        if (linkHeader) {
+          linkHeader.split(',').forEach(link => {
+            const linkMatches = link.match(/<(.+)>; rel="(next|prev|first|last)"/);
+            if (linkMatches && linkMatches.length >= 3) pageLinks[linkMatches[2]] = linkMatches[1];
+          });
+        }
+        return pageLinks;
       },
 
       _onResponse: function(responseBody) {

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -323,7 +323,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
       get requestHeaders() {
         const headers = new Headers();
         var contentType = this.contentType;
-        if (contentType == null && (typeof this.body === 'string')) {
+        if (contentType === null && (typeof this.body === 'string')) {
           contentType = 'application/x-www-form-urlencoded';
         }
         if (contentType) {
@@ -443,10 +443,10 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
         const headers = this.requestHeaders
         const request = new Request(url, {
-            method: this.method,
-            headers: headers,
-            body: this._encodeBody(headers)
-          });
+          method: this.method,
+          headers: headers,
+          body: this._encodeBody(headers)
+        });
         
         return this._fetchOrTimeout(request)
           .then(this._checkResponseForErrors.bind(this))

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -302,6 +302,10 @@ This code may only be used under the BSD style license found in LICENSE.txt
        * @return {string}
        */
       get requestUrl() {
+        if (sharedToken && this.accessToken !== sharedToken) {
+          this.accessToken = sharedToken;
+        }
+
         const queryString = this.queryString;
         const url = this.url || '';
 
@@ -437,10 +441,6 @@ This code may only be used under the BSD style license found in LICENSE.txt
       },
 
       _generateRequest: function(url) {
-        if (sharedToken && this.accessToken !== sharedToken) {
-          this.accessToken = sharedToken;
-        }
-
         const headers = this.requestHeaders
         const request = new Request(url, {
           method: this.method,

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -19,6 +19,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
     Polymer({
       is: 'github-ajax',
       properties: {
+
         /**
          * How many results must be retrieved from GitHub, default 10.
          * @type {Number}
@@ -29,16 +30,18 @@ This code may only be used under the BSD style license found in LICENSE.txt
         },
 
         /**
-         * The nth page from GitHub, used to travers through pagination.
+         * The nth page from GitHub, used to traverse through pagination.
          * @type {Number}
          */
         page: {
           type: Number,
+          readOnly: true,
           observer: '_onPageChange'
         },
 
         /**
          * OAuth access token for authenticated requests, e.g.: fetching the current user.
+         * This property will automatically be shared between all attached instances of `github-ajax`.
          * @type {String}
          */
         accessToken: {
@@ -69,56 +72,142 @@ This code may only be used under the BSD style license found in LICENSE.txt
           value: false
         },
 
+        /**
+         * The url to query, e.g.: https://api.github.com/users
+         * @type {String}
+         */
         url: String,
 
+        /**
+         * URL query parameters to send with the request.
+         * Parameter keys are represented by the object field names,
+         * param values are the values for object fields.
+         * @type{Object}
+         */
         params: {
           type: Object,
           value: function() { return {} }
         },
 
+        /**
+         * The request method to use. Defaults to `GET`.
+         * @type {String}
+         */
         method: {
           type: String,
           value: 'GET'
         },
 
+        /**
+         * Request headers to send with the request.
+         * Header keys are represented by the object field names,
+         * header values are the values for object fields.
+         * Note: setting a `Content-Type` header here will override the value
+         * specified by the `contentType` property of this element.
+         * @type {Object}
+         */
         headers: {
           type: Object,
           value: function() { return {} }
         },
 
+        /**
+         * Content type to use when sending data. If the `contentType` property
+         * is set and a `Content-Type` header is specified in the `headers`
+         * property, the `headers` property value will take precedence.
+         *
+         * Varies the handling of the `body` param.
+         * @type {String}
+         */
         contentType: {
           type: String,
           value: null
         },
 
+         /**
+         * Body content to send with the request, typically used with "POST"
+         * requests.
+         *
+         * If body is a string it will be sent unmodified. 
+         * If the body is a string and contentType is not set,
+         * then the `content-type` will default to `application/x-www-form-urlencoded"`
+         *
+         * If Content-Type is set to a value listed below, then
+         * the body will be encoded accordingly.
+         *
+         *    * `content-type="application/json"`
+         *      * body is encoded like `{"foo":"bar baz","x":1}`
+         *    * `content-type="application/x-www-form-urlencoded"`
+         *      * body is encoded like `foo=bar+baz&x=1`
+         *
+         * Otherwise the body will be passed to the browser unmodified, and it
+         * will handle any encoding (e.g. for FormData, Blob, ArrayBuffer).
+         *
+         * @type (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object)
+         */
         body: {
           type: Object,
           value: null
         },
 
+        /**
+         * Specifies what data to store in the response, and
+         * to deliver in `response` events.
+         *
+         * One of:
+         *
+         *    `text`: uses `response.text()`.
+         *
+         *    `json`: uses `response.json()`.
+         *
+         *    `arraybuffer`: uses `response.arrayBuffer()`.
+         * 
+         * Any other value will result in an error on response.
+         */
         handleAs: {
           type: String,
           value: 'json'
         },
 
+        /**
+         * The most recent request made by this iron-ajax element.
+         * @type {Request}
+         */
         lastRequest: {
           type: Object,
           notify: true,
           readOnly: true
         },
 
+        /**
+         * True while lastRequest is in flight.
+         */
         loading: {
           type: Boolean,
           notify: true,
           readOnly: true,
         },
 
+        /**
+         * The most recent request made by this iron-ajax element.
+         * Note that lastResponse and lastError are set when lastRequest finishes,
+         * so if loading is true, then lastResponse and lastError will correspond
+         * to the result of the previous request.
+         *
+         * The type of the response is determined by the value of `handleAs` at
+         * the time that the request was generated.
+         */
         lastResponse: {
           type: Object,
           notify: true,
           readOnly: true
         },
 
+        /**
+         * lastRequest's error, if any.
+         *
+         * @type {Object}
+         */
         lastError: {
           type: Object,
           notify: true,
@@ -219,7 +308,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           contentType = 'application/x-www-form-urlencoded';
         }
         if (contentType) {
-          headers.append('content-type', contentType);
+          headers.set('content-type', contentType);
         }
 
         var acceptType = {
@@ -233,11 +322,11 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
         if (this.headers instanceof Object) {
           for (header in this.headers) {
-            headers.append(header, this.headers[header].toString());
+            headers.set(header, this.headers[header].toString());
           }
 
           if (acceptType && !headers.has('accept')) {
-            headers.append('accept', acceptType);
+            headers.set('accept', acceptType);
           }
         }
         return headers;
@@ -309,7 +398,6 @@ This code may only be used under the BSD style license found in LICENSE.txt
           .catch(this._onError.bind(this));
       },
 
-      
       _fetchOrTimeout: function(request) {
         this._setLastRequest(request);
         this._setLoading(true);

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -19,6 +19,37 @@ This code may only be used under the BSD style license found in LICENSE.txt
     Polymer({
       is: 'github-ajax',
       properties: {
+        
+        /**
+         * Reflects whether every page of results has been loaded.
+         * If false, call `fetchMore()` to load the next page of results.
+         *
+         * The accumulated results are stored in `allResults`. 
+         * `lastResponse` will only contain the data received from the last requested page.
+         *
+         * The amount of results loaded depends on the `perPage` property,
+         * as well as on whether GitHub decides to honor the value you set in `perPage`.
+         * @type {Boolean}
+         */
+        canFetchMore: {
+          type: Boolean,
+          readOnly: true,
+          notify: true
+        },
+
+        /**
+         * Stores accumulated results from all fetched pages.
+         * If the endpoint you query only returns one result, this array wil contain simply that result.
+         * 
+         * Calling `generateRequest()` will reset this array.
+         * @type {Array}
+         */
+        allResults: {
+          type: Array,
+          readOnly: true,
+          notify: true,
+          value: () => []
+        },
 
         /**
          * How many results must be retrieved from GitHub, default 10.
@@ -379,6 +410,14 @@ This code may only be used under the BSD style license found in LICENSE.txt
         }
       },
 
+      /**
+       * Performs an AJAX request to the specified URL.
+       * This will reset the results stored in `allResults`.
+       * If the queried endpoint supports pagination, the first page will be loaded.
+       * 
+       * Returns a Promise that resolves when the request completes and after any events have been fired.
+       * @return {Promise}
+       */
       generateRequest: function() {
         if (sharedToken && this.accessToken !== sharedToken) {
           this.accessToken = sharedToken;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-ajax",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "main": "index.html",
   "repository": "https://github.com/preview-code/github-ajax.git",

--- a/test/fetch-test-helpers.js
+++ b/test/fetch-test-helpers.js
@@ -18,6 +18,8 @@ const respondWith = async (code, headers, body) => () => new Response(JSON.strin
   headers: headers
 });
 
+const ok = async (headers, body) => await respondWith(200, headers, body);
+
 const echoJson = async request => (await jsonOk(request.url))();
 
 const onRequest = fn => {

--- a/test/github-ajax.html
+++ b/test/github-ajax.html
@@ -61,6 +61,12 @@ This code may only be used under the BSD style license found in LICENSE.txt
     </template>
   </test-fixture>
 
+  <test-fixture id="Pagination">
+    <template>
+      <github-ajax id="ajax" no-cache url="https://api.github.com"></github-ajax>
+    </template>
+  </test-fixture>
+
   <script>
     'use strict';
     describe('<github-ajax>', function () {
@@ -456,7 +462,6 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
       });
 
-
       describe('when making a POST over the wire', () => {
         beforeEach(() => {
           window.fetch.restore();
@@ -589,24 +594,6 @@ This code may only be used under the BSD style license found in LICENSE.txt
           await ajax.generateRequest();
         });
 
-        it('does not add `page` to request headers if `page` property is not present', async () => {
-          onRequest((request) => {
-            expect(getRequestParam(request.url, 'page')).to.be.undefined;
-            return jsonOk({});
-          });
-          await ajax.generateRequest();
-        });
-
-        it('adds `page` to request headers if `page` property is present', async () => {
-          onRequest(request => {
-            expect(getRequestParam(request.url, 'page')).to.equal('42');
-            return jsonOk({hello: 'world'})
-          });
-          
-          ajax.page = 42;
-          await ajax.generateRequest();
-        });
-
         it('access token is shared between instances', done => {
           ajax.accessToken = token;
           expect(ajax.params.access_token).to.equal(token);
@@ -621,6 +608,188 @@ This code may only be used under the BSD style license found in LICENSE.txt
             expect(el.params.access_token).to.equal(token);
             done();
           }, 100);
+        });
+      });
+
+      describe('Handles pagination', () => {
+        const pages = [
+          // First page
+          '<https://api.github.com/x?page=2>; rel="next", <https://api.github.com/x?page=3>; rel="last"',
+          // Second page
+          '<https://api.github.com/x?page=3>; rel="next", <https://api.github.com/x?page=3>; rel="last", <https://api.github.com/x?page=1>; rel="first", <https://api.github.com/x?page=1>; rel="prev"',
+          // Last page
+          '<https://api.github.com/x?page=1>; rel="first", <https://api.github.com/x?page=2>; rel="prev"'
+        ]
+        const firstPageHeaders = { 'Link': pages[0] };
+        const secondPageHeaders = { 'Link': pages[1] };
+        const lastPageHeaders = { 'Link': pages[2] };
+
+        beforeEach(() => {
+          ajax = fixture('Pagination');
+          onRequest(wait);
+          ajax._onError = e => { throw e }
+        })
+
+        it('does not add `page` to request headers on `generateRequest`', done => {
+          onRequest(request => {
+            expect(getRequestParam(request.url, 'page')).to.be.undefined;
+            done();
+          });
+          ajax.generateRequest();
+        });
+
+        it('Should set canFetchMore to true if nothing has been fetched yet', () => {
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('does not add `page` to request headers when `fetchMore` is the first request', done => {
+          onRequest(request => {
+            expect(getRequestParam(request.url, 'page')).to.be.undefined;
+            done();
+          });
+          ajax.fetchMore();
+        });
+
+        it('adds `page` to request headers when `fetchMore` is called after `generateRequest`', async () => {
+          onRequest(() => ok(firstPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+
+          onRequest(request => {
+            expect(getRequestParam(request.url, 'page')).to.equal('2');
+            return jsonOk([]);
+          });
+          await ajax.fetchMore();
+          expect(ajax.lastResponse).to.deep.equal([]);
+        });
+
+        it('does not generate a request when calling fetchMore on the last page', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+
+          onRequest(() => done(new Error('Expected no request to be fired')));
+          await ajax.fetchMore();
+        });
+
+        it('Should set canFetchMore to false when the resource is not paginated', async () => {
+          onRequest(() => jsonOk([]));
+          await ajax.generateRequest();
+          expect(ajax.canFetchMore).to.be.false;
+        });
+
+        it('Should set canFetchMore to true as long as there are multiple pages', async () => {
+          onRequest(() => ok(firstPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          expect(ajax.canFetchMore).to.be.true;
+
+          onRequest(() => ok(secondPageHeaders, [{number: '3'}, {number: '4'}]));
+          await ajax.fetchMore();
+          expect(ajax.canFetchMore).to.be.true;
+
+          onRequest(() => ok(lastPageHeaders, [{number: '5'}, {number: '6'}]));
+          await ajax.fetchMore();
+          expect(ajax.canFetchMore).to.be.false;
+        });
+
+        it('Should set canFetchMore to false when the last page is fetched', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '5'}, {number: '6'}]));
+          await ajax.generateRequest();
+          expect(ajax.canFetchMore).to.be.false;
+        });
+
+        it('should reset pagination when the URL changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.url = 'https://api.github.com/blah';
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `method` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.method = 'POST';
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `perPage` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.perPage = 23490234;
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `params` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.set('params.parameter', 'value');
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `contentType` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.contentType = 'text/plain';
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `body` changes', async () => {
+          ajax.method = 'POST';
+          ajax.body = {key: 'value'};
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.body = {key: 'value2'};
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `headers` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.set('headers.X-Espresso', 'Tripple-Please');
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('should reset pagination when `handleAs` changes', async () => {
+          onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          ajax.handleAs = 'beverage';
+          expect(ajax.canFetchMore).to.be.true;
+        });
+
+        it('Stores the first ever response in allResults', async () => {
+          onRequest(() => jsonOk([1,2,3]));
+          await ajax.generateRequest();
+          expect(ajax.allResults).to.deep.equal([1,2,3]);
+        });
+
+        it('Stores the all consequently fetched pages in allResults', async () => {
+          onRequest(() => ok(firstPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+
+          onRequest(() => ok(secondPageHeaders, [{number: '3'}, {number: '4'}]));
+          await ajax.fetchMore();
+
+          onRequest(() => ok(lastPageHeaders, [{number: '5'}, {number: '6'}]));
+          await ajax.fetchMore();
+          expect(ajax.allResults).to.deep.equal([{number: '1'}, {number: '2'}, {number: '3'}, {number: '4'}, {number: '5'}, {number: '6'}]);
+        });
+
+        it('Resets allResults when `generateRequest` is called', async () => {
+          onRequest(() => ok(firstPageHeaders, [{number: '1'}, {number: '2'}]));
+          await ajax.generateRequest();
+          expect(ajax.allResults).to.deep.equal([{number: '1'}, {number: '2'}]);
+
+          onRequest(() => ok(firstPageHeaders, [{number: '3'}, {number: '4'}]));
+          await ajax.generateRequest();
+          expect(ajax.allResults).to.deep.equal([{number: '3'}, {number: '4'}]);
+        });
+
+        it('Fetches the URL provided in the `Link` header when calling `fetchMore`', async () => {
+          onRequest(() => ok({ 'Link': '<https://api.github.com/beverage/espresso>; rel="next"' }, []));
+          await ajax.generateRequest();
+          onRequest(request => {
+            expect(request.url).to.equal('https://api.github.com/beverage/espresso')
+            return jsonOk([]);
+          });
+          await ajax.fetchMore();
         });
       });
     });

--- a/test/github-ajax.html
+++ b/test/github-ajax.html
@@ -141,7 +141,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           expect(ajax.queryString).to.be.equal('');
           expect(ajax.requestUrl).to.be.equal('');
 
-          ajax.params = {'a':'b', 'c':'d'};
+          ajax.params = {'a': 'b', 'c': 'd'};
 
           expect(ajax.queryString).to.be.equal('a=b&c=d');
           expect(ajax.requestUrl).to.be.equal('?a=b&c=d');
@@ -163,7 +163,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           ajax = fixture('BlankUrl');
           expect(ajax.url).to.be.equal(undefined);
 
-          ajax.params = {'a':'b', 'c':'d'};
+          ajax.params = {'a': 'b', 'c': 'd'};
           onRequest(request => {
             expect(request.url).to.be.eql(window.location.href + '?a=b&c=d');
             return jsonOk({success: true});
@@ -204,7 +204,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
 
         it('encodes array params properly', () => {
-          ajax.params = {'a b': ['c','d e', 'f']};
+          ajax.params = {'a b': ['c', 'd e', 'f']};
           expect(ajax.queryString).to.be.equal('a%20b=c&a%20b=d%20e&a%20b=f');
         });
 
@@ -295,7 +295,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
 
         it('by default, the body is json encoded', async () => {
-          var requestObj = {foo: 'bar', baz: [1,2,3]}
+          var requestObj = {foo: 'bar', baz: [1, 2, 3]}
           ajax.body = requestObj;
           ajax.contentType = 'application/json';
 
@@ -310,7 +310,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
 
         it('if `contentType` is json, the body is json encoded', async () => {
-          var requestObj = {foo: 'bar', baz: [1,2,3]}
+          var requestObj = {foo: 'bar', baz: [1, 2, 3]}
           ajax.body = requestObj;
           ajax.contentType = 'application/json';
 
@@ -406,9 +406,9 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
       describe('when a request fails', () => {
         const expectedError = {
-            message: 'Bad Gateway',
-            errorCode: 502
-          }
+          message: 'Bad Gateway',
+          errorCode: 502
+        }
 
         beforeEach(() => {
           ajax = fixture('TrivialGet');
@@ -620,9 +620,9 @@ This code may only be used under the BSD style license found in LICENSE.txt
           // Last page
           '<https://api.github.com/x?page=1>; rel="first", <https://api.github.com/x?page=2>; rel="prev"'
         ]
-        const firstPageHeaders = { 'Link': pages[0] };
-        const secondPageHeaders = { 'Link': pages[1] };
-        const lastPageHeaders = { 'Link': pages[2] };
+        const firstPageHeaders = {'Link': pages[0]};
+        const secondPageHeaders = {'Link': pages[1]};
+        const lastPageHeaders = {'Link': pages[2]};
 
         beforeEach(() => {
           ajax = fixture('Pagination');
@@ -666,7 +666,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           onRequest(() => ok(lastPageHeaders, [{number: '1'}, {number: '2'}]));
           await ajax.generateRequest();
 
-          onRequest(() => done(new Error('Expected no request to be fired')));
+          onRequest(() => { throw new Error('Expected no request to be fired') });
           await ajax.fetchMore();
         });
 
@@ -755,9 +755,9 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
 
         it('Stores the first ever response in allResults', async () => {
-          onRequest(() => jsonOk([1,2,3]));
+          onRequest(() => jsonOk([1, 2, 3]));
           await ajax.generateRequest();
-          expect(ajax.allResults).to.deep.equal([1,2,3]);
+          expect(ajax.allResults).to.deep.equal([1, 2, 3]);
         });
 
         it('Stores the all consequently fetched pages in allResults', async () => {
@@ -783,7 +783,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         });
 
         it('Fetches the URL provided in the `Link` header when calling `fetchMore`', async () => {
-          onRequest(() => ok({ 'Link': '<https://api.github.com/beverage/espresso>; rel="next"' }, []));
+          onRequest(() => ok({'Link': '<https://api.github.com/beverage/espresso>; rel="next"'}, []));
           await ajax.generateRequest();
           onRequest(request => {
             expect(request.url).to.equal('https://api.github.com/beverage/espresso')

--- a/test/github-ajax.html
+++ b/test/github-ajax.html
@@ -64,7 +64,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
   <script>
     'use strict';
     describe('<github-ajax>', function () {
-      var ajax, anotherAjax;
+      var ajax;
       var token = 'VERY_SECRET_TOKEN';
 
       beforeEach(() => {
@@ -221,7 +221,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
             return jsonOk({success: true});
           });
 
-          await ajax.generateRequest();;
+          await ajax.generateRequest();
 
           ajax.params = {b: 'b'};
           onRequest(request => {
@@ -320,7 +320,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
         describe('and `contentType` is explicitly set to form encode', () => {
           it('we encode a custom object', async () => {
-            function Foo(bar) { this.bar = bar };
+            function Foo(bar) { this.bar = bar }
             var requestObj = new Foo('baz');
             ajax.body = requestObj;
             ajax.contentType = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
This adds two properties and one method to the API:
- `canFetchMore`, true iff the last response was paginated and more pages can be fetched.
- `fetchMore()`, call to generate a request for the next page, or for the first page if nor previous request has been made.
- `allResults`, an array containing results from all fetched pages.

Will rebase after #3 has been merged