### PR TITLE
we do not error on ok-status codes 201-299

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "github-ajax",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "github-ajax.html",
   "description": "Fetch API wrapper targeted towards usage with the GitHub API",
   "authors": [

--- a/github-ajax.html
+++ b/github-ajax.html
@@ -19,12 +19,12 @@ This code may only be used under the BSD style license found in LICENSE.txt
     Polymer({
       is: 'github-ajax',
       properties: {
-        
+
         /**
          * Reflects whether every page of results has been loaded.
          * If false, call `fetchMore()` to load the next page of results.
          *
-         * The accumulated results are stored in `allResults`. 
+         * The accumulated results are stored in `allResults`.
          * `lastResponse` will only contain the data received from the last requested page.
          *
          * The amount of results loaded depends on the `perPage` property,
@@ -41,7 +41,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         /**
          * Stores accumulated results from all fetched pages.
          * If the endpoint you query only returns one result, this array wil contain simply that result.
-         * 
+         *
          * Calling `generateRequest()` will reset this array.
          * @type {Array}
          */
@@ -74,10 +74,10 @@ This code may only be used under the BSD style license found in LICENSE.txt
         /**
          * Amount of milliseconds before the request is considered to be timed out.
          * A timeout triggers the `github-error` event and sets the appropriate lastError and lastRequest property.
-         * 
+         *
          * Note that the timeout property cannot cancel the actual in-flight request,
          * since the Fetch API does not yet have support for interrupting requests.
-         * 
+         *
          * @type {Number}
          */
         timeout: {
@@ -146,7 +146,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
          * Body content to send with the request, typically used with "POST"
          * requests.
          *
-         * If body is a string it will be sent unmodified. 
+         * If body is a string it will be sent unmodified.
          * If the body is a string and contentType is not set,
          * then the `content-type` will default to `application/x-www-form-urlencoded"`
          *
@@ -180,7 +180,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
          *    `json`: uses `response.json()`.
          *
          *    `arraybuffer`: uses `response.arrayBuffer()`.
-         * 
+         *
          * Any other value will result in an error on response.
          */
         handleAs: {
@@ -238,7 +238,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           type: String
         }
       },
-      
+
       observers: [
         '_resetPagination(params.*, headers.*)'
       ],
@@ -406,7 +406,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
        * Performs an AJAX request to the specified URL.
        * This will reset the results stored in `allResults`.
        * If the queried endpoint supports pagination, the first page will be loaded.
-       * 
+       *
        * Returns a Promise that resolves when the request completes and after any events have been fired.
        * @return {Promise}
        */
@@ -419,7 +419,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
        * If `canFetchMore` returns true, this method will
        * request the next page of results.
        * These results will be concatenated to `allResults`.
-       * 
+       *
        * Returns a Promise that resolves when the request completes and after any events have been fired.
        * Just like `generateRequest`, this method will fire `github-response` & co events.
        * @return {Promise}
@@ -447,7 +447,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           headers: headers,
           body: this._encodeBody(headers)
         });
-        
+
         return this._fetchOrTimeout(request)
           .then(this._checkResponseForErrors.bind(this))
           .then(this._decodeResponseBody.bind(this))
@@ -463,7 +463,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         this._setLastRequest(request);
         this._setLoading(true);
         this.fire('github-request', request);
-        
+
         return Promise.race([this._timeout(), fetch(request).then(response => ({
           request: request,
           response: response
@@ -481,7 +481,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
       _checkResponseForErrors: function(o) {
         if (this.lastRequest === o.request) {
-          if (o.response.status === 200) {
+          if (o.response.ok) {
             return Promise.resolve(o.response);
           } else {
             return Promise.reject({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-ajax",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "main": "index.html",
   "repository": "https://github.com/preview-code/github-ajax.git",

--- a/test/github-ajax.html
+++ b/test/github-ajax.html
@@ -21,14 +21,14 @@ This code may only be used under the BSD style license found in LICENSE.txt
       <github-ajax url="https://api.github.com" no-cache></github-ajax>
     </template>
   </test-fixture>
-  
+
   <test-fixture id="TrivialPost">
     <template>
       <github-ajax method="POST"
                    url="https://api.github.com" no-cache></github-ajax>
     </template>
   </test-fixture>
-  
+
   <test-fixture id='BlankUrl'>
     <template>
       <github-ajax no-cache></github-ajax>
@@ -90,7 +90,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           setTimeout(done, 100);
         });
       });
-      
+
       describe('when making simple GET requests for JSON', () => {
         it('has sane defaults that love you', async () => {
           onRequest(async request => {
@@ -187,7 +187,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
             expect(request.method).to.be.equal('POST');
             return jsonOk({success: true});
           });
-          
+
           ajax.generateRequest();
         });
       });
@@ -222,7 +222,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
       describe('when params are changed', () => {
         it('generates a request that reflects the change', async () => {
           ajax.params = {a: 'a'};
-          
+
           onRequest(request => {
             expect(request.url).to.be.equal('https://api.github.com/?a=a');
             return jsonOk({success: true});
@@ -331,14 +331,14 @@ This code may only be used under the BSD style license found in LICENSE.txt
             var requestObj = new Foo('baz');
             ajax.body = requestObj;
             ajax.contentType = 'application/x-www-form-urlencoded';
-            
+
             onPOST(async request => {
               expect(request).to.be.ok;
               const body = await request.text();
               expect(body).to.equal('bar=baz');
               return jsonOk({success: true});
             });
-            
+
             await ajax.generateRequest();
           });
         });
@@ -347,7 +347,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           it('we don\'t try to encode an ArrayBuffer', async () => {
             var requestObj = new ArrayBuffer()
             ajax.body = requestObj;
-            
+
             onPOST(async request => {
               expect(request).to.be.ok;
               // We give the browser the ArrayBuffer directly, without trying
@@ -357,7 +357,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
               expect(body).to.deep.equal(requestObj);
               return jsonOk({success: true});
             });
-            
+
             await ajax.generateRequest();
           });
         })
@@ -404,6 +404,18 @@ This code may only be used under the BSD style license found in LICENSE.txt
           expect(typeof(ajax.lastResponse)).to.be.equal('string');
         });
       });
+
+      describe('ok request', () => {
+
+        it.only('Accepts the request promise on HTTP ok', async () => {
+          ajax._onError = e => { throw e }
+
+          onRequest(() => respondWith(203, new Headers(), 'OK'));
+
+          await ajax.generateRequest();
+          expect(ajax.lastResponse).to.deep.equal('OK');
+        });
+      })
 
       describe('when a request fails', () => {
         const expectedError = {
@@ -486,7 +498,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         })
 
         // This fails on firefox 52 for some reason.
-        // Issue is described at: 
+        // Issue is described at:
         //    https://github.com/webcomponents/webcomponentsjs/issues/752
         it.skip('FormData is handled correctly', async () => {
           const requestBody = new FormData();
@@ -495,9 +507,9 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
           ajax.body = requestBody;
           await ajax.generateRequest();
-          
+
           // httpbin echoes the request back as response body
-          const sentRequest = ajax.lastResponse; 
+          const sentRequest = ajax.lastResponse;
           expect(sentRequest.headers['Content-Type']).to.match(
               /^multipart\/form-data; boundary=.*$/);
 
@@ -533,7 +545,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
           ajax = fixture('Timeout');
           respond = onRequest(wait);
         });
-        
+
         it('fires `github-error` on timeout', done => {
           ajax.addEventListener('github-error', e => {
             expect(e.detail.timeout).to.be.true;
@@ -573,7 +585,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
 
       describe('GitHub specific properties', () => {
         var anotherAjax;
-        
+
         beforeEach(() => {
           ajax = fixture('MultipleElements')[0];
           anotherAjax = fixture('MultipleElements')[1];
@@ -594,7 +606,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
             expect(getRequestParam(request.url, 'access_token')).to.equal(token);
             return jsonOk({hello: 'world'})
           });
-          
+
           ajax.accessToken = token;
           await ajax.generateRequest();
         });
@@ -612,7 +624,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
             expect(getRequestParam(request.url, 'per_page')).to.equal('42');
             return jsonOk({hello: 'world'})
           });
-          
+
           ajax.perPage = 42;
           await ajax.generateRequest();
         });
@@ -620,7 +632,7 @@ This code may only be used under the BSD style license found in LICENSE.txt
         it('access token is shared between instances', done => {
           ajax.accessToken = token;
           expect(ajax.params.access_token).to.equal(token);
-          
+
           expect(anotherAjax.accessToken).to.equal(token);
           expect(anotherAjax.params.access_token).to.equal(token);
 


### PR DESCRIPTION
In order to let preview-code/minimal-frontend#31 work.

There are a few extra 'styling' changes in `github-ajax.html`. They came automatic when editing that one line (I do not have autoformat on, that results in even more changes).